### PR TITLE
show gameComment in PgnViewer

### DIFF
--- a/src/js/pgnViewer.js
+++ b/src/js/pgnViewer.js
@@ -133,6 +133,10 @@ export function highlightCurrentMove(pgnPath) {
 export function initPgnViewer() {
     state.pgnPath = [];
     const pgnContainer = document.getElementById('pgnComment');
-    pgnContainer.innerHTML = buildPgnHtml(parsedPGN.moves);
+    pgnContainer.innerHTML = '';
+    if (parsedPGN.gameComment) {
+        pgnContainer.innerHTML += `<span class="comment"> ${parsedPGN.gameComment.comment} </span>`;
+    }
+    pgnContainer.innerHTML += buildPgnHtml(parsedPGN.moves);
     pgnContainer.addEventListener('click', onPgnMoveClick);
 }


### PR DESCRIPTION
Many of my pgn files have a game comment that precedes the move list. pgn-parser reads this comment into the parsedPGN.gameComment.comment property. This pull request would modify initPgnViewer to add this comment when it exists at the beginning of pgnContainer.innerHTML.

Thanks for your consideration.

Example PGN:

`[Event "The Opera Game"]
    [Site "Paris Opera House"]
    [Date "1858.11.02"]
    [Round "?"]
    [White "Paul Morphy"]
    [Black "Duke of Brunswick &amp; Count Isouart"]
    [Result "1-0"]
    [ECO "C41"]

    {This is a game comment that precedes the move list.} 1. e4 e5 2. Nf3 d6 {This is the Philidor Defence. It's solid but can be passive.} `