### PR TITLE
replace anki-persistence with sessionStorage

### DIFF
--- a/Note_Template/Back.html
+++ b/Note_Template/Back.html
@@ -8,10 +8,6 @@
         showDests: true, // Indicate legal moves for clicked piece.
     }
 </script>
-<script>
-// v1.1.8 - https://github.com/SimonLammer/anki-persistence/blob/584396fea9dea0921011671a47a0fdda19265e62/script.js
-if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/",t="_default";if(window.Persistence_sessionStorage=function(){var i=!1;try{"object"==typeof window.sessionStorage&&(i=!0,this.clear=function(){for(var t=0;t<sessionStorage.length;t++){var i=sessionStorage.key(t);0==i.indexOf(e)&&(sessionStorage.removeItem(i),t--)}},this.setItem=function(i,n){void 0==n&&(n=i,i=t),sessionStorage.setItem(e+i,JSON.stringify(n))},this.getItem=function(i){return void 0==i&&(i=t),JSON.parse(sessionStorage.getItem(e+i))},this.removeItem=function(i){void 0==i&&(i=t),sessionStorage.removeItem(e+i)},this.getAllKeys=function(){for(var t=[],i=Object.keys(sessionStorage),n=0;n<i.length;n++){var s=i[n];0==s.indexOf(e)&&t.push(s.substring(e.length,s.length))}return t.sort()})}catch(n){}this.isAvailable=function(){return i}},window.Persistence_windowKey=function(i){var n=window[i],s=!1;"object"==typeof n&&(s=!0,this.clear=function(){n[e]={}},this.setItem=function(i,s){void 0==s&&(s=i,i=t),n[e][i]=s},this.getItem=function(i){return void 0==i&&(i=t),void 0==n[e][i]?null:n[e][i]},this.removeItem=function(i){void 0==i&&(i=t),delete n[e][i]},this.getAllKeys=function(){return Object.keys(n[e])},void 0==n[e]&&this.clear()),this.isAvailable=function(){return s}},window.Persistence=new Persistence_sessionStorage,Persistence.isAvailable()||(window.Persistence=new Persistence_windowKey("py")),!Persistence.isAvailable()){var i=window.location.toString().indexOf("title"),n=window.location.toString().indexOf("main",i);i>0&&n>0&&n-i<10&&(window.Persistence=new Persistence_windowKey("qt"))}}
-</script>
 
 <iframe id="analysisBoard" style="visibility: hidden"></iframe>
 
@@ -22,13 +18,13 @@ if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/"
     var userText = `{{textField}}`
     userText = encodeURIComponent(userText)
     {{/textField}}
-        var errorTrack;
-        var mirrorState;
-        if (Persistence.isAvailable()) {
-            errorTrack = Persistence.getItem("errorTrack");
-            mirrorState = Persistence.getItem("mirrorState");
-            Persistence.clear();
-        }
+
+    var errorTrack;
+    var mirrorState;
+    errorTrack = sessionStorage.getItem("errorTrack");
+    mirrorState = sessionStorage.getItem("mirrorState");
+    sessionStorage.clear();
+    
 </script>
 
 <script>

--- a/Note_Template/Front.html
+++ b/Note_Template/Front.html
@@ -14,10 +14,6 @@
     }
 
 </script>
-<script>
-// v1.1.8 - https://github.com/SimonLammer/anki-persistence/blob/584396fea9dea0921011671a47a0fdda19265e62/script.js
-if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/",t="_default";if(window.Persistence_sessionStorage=function(){var i=!1;try{"object"==typeof window.sessionStorage&&(i=!0,this.clear=function(){for(var t=0;t<sessionStorage.length;t++){var i=sessionStorage.key(t);0==i.indexOf(e)&&(sessionStorage.removeItem(i),t--)}},this.setItem=function(i,n){void 0==n&&(n=i,i=t),sessionStorage.setItem(e+i,JSON.stringify(n))},this.getItem=function(i){return void 0==i&&(i=t),JSON.parse(sessionStorage.getItem(e+i))},this.removeItem=function(i){void 0==i&&(i=t),sessionStorage.removeItem(e+i)},this.getAllKeys=function(){for(var t=[],i=Object.keys(sessionStorage),n=0;n<i.length;n++){var s=i[n];0==s.indexOf(e)&&t.push(s.substring(e.length,s.length))}return t.sort()})}catch(n){}this.isAvailable=function(){return i}},window.Persistence_windowKey=function(i){var n=window[i],s=!1;"object"==typeof n&&(s=!0,this.clear=function(){n[e]={}},this.setItem=function(i,s){void 0==s&&(s=i,i=t),n[e][i]=s},this.getItem=function(i){return void 0==i&&(i=t),void 0==n[e][i]?null:n[e][i]},this.removeItem=function(i){void 0==i&&(i=t),delete n[e][i]},this.getAllKeys=function(){return Object.keys(n[e])},void 0==n[e]&&this.clear()),this.isAvailable=function(){return s}},window.Persistence=new Persistence_sessionStorage,Persistence.isAvailable()||(window.Persistence=new Persistence_windowKey("py")),!Persistence.isAvailable()){var i=window.location.toString().indexOf("title"),n=window.location.toString().indexOf("main",i);i>0&&n>0&&n-i<10&&(window.Persistence=new Persistence_windowKey("qt"))}}
-</script>
 <iframe id="Board" style="visibility: hidden"></iframe>
 <script>
 
@@ -35,16 +31,16 @@ if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/"
         var iframe = document.getElementById("Board");
         iframe.onload = function() { iframe.style.visibility = "visible"; }
         iframe.src = `_chess3.0.html?{{#textField}}userText=` + userText + `&{{/textField}}PGN=` + PGN + `&flip=`+userConfig.flip+`&handicap=` + userConfig.handicap + `&background=`+background+`&acceptVariations=`+userConfig.acceptVariations+`&disableArrows=`+userConfig.disableArrows+`&frontText=`+userConfig.frontText+`&fontSize=`+userConfig.fontSize+`&muteAudio=`+userConfig.muteAudio+`&mirror=`+userConfig.mirror+`&showDests=`+userConfig.showDests+`&boardMode=Puzzle`;
+
         var errorTrack;
         var mirrorState;
-        if (Persistence.isAvailable()) {
-            Persistence.clear();
-            if (typeof window.addEventListener != 'undefined') {
+
+        if (typeof window.addEventListener != 'undefined') {
                 window.addEventListener('message', function(e) {
                     errorTrack = e.data.errorTrack;
                     mirrorState = e.data.mirrorState;
-                    Persistence.setItem("errorTrack", errorTrack);
-                    Persistence.setItem("mirrorState", mirrorState);
+                    sessionStorage.setItem("errorTrack", errorTrack);
+                    sessionStorage.setItem("mirrorState", mirrorState);
                 }, false);
             }
         }


### PR DESCRIPTION
Anki-persistence uses different mechanisms to persist data in Anki and AnkiDroid. This pull request would replace anki-persistence with the simpler sessionStorage, which was implemented in Anki 2.1.50 ([some discussion here](https://forums.ankiweb.net/t/is-it-even-possible-to-persist-javascript-variables-on-ankidroid/19820/2)) and is what anki-persistence uses internally on AnkiDroid already.

I have done basic testing in Windows and Android. I don't have easy access to IOS devices.  

I thought this would fix my bug with the auto-advance pull request but it didn't.