### PR TITLE
errorTrack false default causes borders to turn green with mirror even if puzzle unanswered

### DIFF
--- a/Note_Template/Front.html
+++ b/Note_Template/Front.html
@@ -35,8 +35,8 @@ if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/"
         var iframe = document.getElementById("Board");
         iframe.onload = function() { iframe.style.visibility = "visible"; }
         iframe.src = `_chess3.0.html?{{#textField}}userText=` + userText + `&{{/textField}}PGN=` + PGN + `&flip=`+userConfig.flip+`&handicap=` + userConfig.handicap + `&background=`+background+`&acceptVariations=`+userConfig.acceptVariations+`&disableArrows=`+userConfig.disableArrows+`&frontText=`+userConfig.frontText+`&fontSize=`+userConfig.fontSize+`&muteAudio=`+userConfig.muteAudio+`&mirror=`+userConfig.mirror+`&showDests=`+userConfig.showDests+`&boardMode=Puzzle`;
-        var errorTrack;
-        var mirrorState;
+        var errorTrack = null;
+        var mirrorState = null;
         if (Persistence.isAvailable()) {
             Persistence.clear();
             if (typeof window.addEventListener != 'undefined') {

--- a/src/main.js
+++ b/src/main.js
@@ -78,9 +78,6 @@ let state = {
     blunderNags: ['$2', '$4', '$6', '$9'],
 };
 
-if (!state.errorTrack) {
-    state.errorTrack = false;
-}
 
 // --- Stockfish Analysis State ---
 let cg = null;
@@ -433,6 +430,8 @@ function playAiMove(cg, chess, delay) {
         state.expectedMove = state.expectedLine[state.count];
 
         if (!state.expectedMove || typeof state.expectedMove === 'string') {
+            // explicitly set state.errorTrack to false (as opposed to null) to track a correct answer
+            if (state.errorTrack === null) state.errorTrack = false;
             window.parent.postMessage(state, '*');
             document.documentElement.style.setProperty('--border-color', state.solvedColour);
             cg.set({
@@ -532,6 +531,8 @@ function checkUserMove(cg, chess, moveSan, delay) {
         if (state.expectedMove && delay) {
             playAiMove(cg, chess, delay);
         } else if (delay) {
+            // explicitly set state.errorTrack to false (as opposed to null) to track a correct answer
+            if (state.errorTrack === null) state.errorTrack = false;
             window.parent.postMessage(state, '*');
             document.documentElement.style.setProperty('--border-color', state.solvedColour);
             cg.set({


### PR DESCRIPTION
This is a minor bug to which this pull request proposes a quick and dirty fix.

The viewer checks for errorTrack true/false and if false, sets the border to green. The puzzle sets errorTrack to false by default, but if no move is attempted In ordinary operation (i.e., the user clicks Show Answer before attempting to move), there is no postMessage, and the viewer sees errorTrack as null, so correctly does not change the border color to either red or green.

However, if mirror is true, the mirror code has its own postMessage call and the default false value of errorTrack gets propagated to the viewer. This causes the border to turn green if the user clicks Show Answer without having attempted any moves which I believe is not the desired behavior.

The pull request removes the default setting of false for errorTrack (keeping it null) and explicitly sets it to false when the puzzle is solved correctly. Thus the border remains white or black when Show Answer is clicked without attempting to move instead of turning green.