### PR TITLE
add mirror-border-fix changes back after auto-advance merge resolution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -432,6 +432,8 @@ function playAiMove(cg, chess, delay) {
         state.expectedMove = state.expectedLine[state.count];
 
         if (!state.expectedMove || typeof state.expectedMove === 'string') {
+            // explicitly set state.errorTrack to false (as opposed to null) to track a correct answer
+            if (state.errorTrack === null) state.errorTrack = false;
 	    state.puzzleComplete = true;
 	    if (config.autoAdvance) {
                 setTimeout(() => { window.parent.postMessage(state, '*'); }, 200);
@@ -536,8 +538,10 @@ function checkUserMove(cg, chess, moveSan, delay) {
         if (state.expectedMove && delay) {
             playAiMove(cg, chess, delay);
         } else if (delay) {
+            // explicitly set state.errorTrack to false (as opposed to null) to track a correct answer
+            if (state.errorTrack === null) state.errorTrack = false;
             state.puzzleComplete = true;
-	          if (config.autoAdvance) {
+	    if (config.autoAdvance) {
                 setTimeout(() => { window.parent.postMessage(state, '*'); }, 200);
             } else {
 		        window.parent.postMessage(state, '*');


### PR DESCRIPTION
Changes from mirror-border-fix got overwritten when you pulled auto-advance into main due to my two pull requests having a merge conflict that could only be fixed manually. This pull request simply adds the overwriten changes from mirror-border-fix back in now that auto-advance has been merged into main.  Thanks for doing that btw!!

Original merged pull request here: #92 