### PR TITLE
parse arrows from pgn comments and display in Viewer

### DIFF
--- a/src/js/mirror.js
+++ b/src/js/mirror.js
@@ -6,6 +6,15 @@ export function assignMirrorState(pgn) {
   return mirrorState;
 }
 
+export function mirrorGameCommentArrows(pgn, mirrorState) {
+  if (pgn.gameComment?.colorArrows?.length > 0) {
+     const notationMap = getMirrorNotationMap(mirrorState);
+     for (let i = 0; i < pgn.gameComment.colorArrows.length; i++) { 
+        pgn.gameComment.colorArrows[i] = pgn.gameComment.colorArrows[i].split('').map(char => notationMap[char] || char).join('');
+     }
+  }
+}
+
 export function mirrorFenRow(row) {
   let result = row.split('').reverse().join('');
   return result;
@@ -43,22 +52,30 @@ export function swapCase(str) {
   ).join('');
 }
 
-export function mirrorMove(move, mirrorState) {
-  var notations = {}
-
+export function getMirrorNotationMap(mirrorState) {
   const notationMaps = {
     "invert_mirror": { q: 'q', a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', 1: '8', 2: '7', 3: '6', 4: '5', 5: '4', 6: '3', 7: '2', 8: '1' },
     "invert": { q: 'q', a: 'h', b: 'g', c: 'f', d: 'e', e: 'd', f: 'c', g: 'b', h: 'a', 1: '8', 2: '7', 3: '6', 4: '5', 5: '4', 6: '3', 7: '2', 8: '1' },
     "original_mirror": { q: 'q', a: 'h', b: 'g', c: 'f', d: 'e', e: 'd', f: 'c', g: 'b', h: 'a', 1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8' },
     "original": { q: 'q', a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', 1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8' }
   }
+  return notationMaps[mirrorState] || notationMaps.original;
+}
 
-  const notationMap = notationMaps[mirrorState] || notationMaps.original;
+export function mirrorMove(move, mirrorState) {
+
+  const notationMap = getMirrorNotationMap(mirrorState);
 
   if (move.notation.disc) move.notation.disc = move.notation.disc.split('').map(char => notationMap[char] || char).join('');
   if (move.notation.col) move.notation.col = move.notation.col.split('').map(char => notationMap[char] || char).join('');
   if (move.notation.row) move.notation.row = move.notation.row.split('').map(char => notationMap[char] || char).join('');
   move.notation.notation = move.notation.notation.split('').map(char => notationMap[char] || char).join('');
+
+  if (move.commentDiag?.colorArrows?.length > 0) {
+    for (let i = 0; i < move.commentDiag.colorArrows.length; i++) {
+        move.commentDiag.colorArrows[i] = move.commentDiag.colorArrows[i].split('').map(char => notationMap[char] || char).join('');
+    }
+  }
 
 }
 


### PR DESCRIPTION
pgn-parser is able to parse standard tags like [%cal Gb1c3, Rc3d4] from the pgn comment fields, reading them into move.commentDiag.colorArrows (and parsedPGN.gameComment.colorArrows) arrays.  This pull request would show these arrows from the pgn on the Viewer board using the four color brushes (red/green/blue/yellow).

This is the last significant feature from my old custom codebase that I wanted to implement for my personal use.

Let me know your thoughts.  If you are interested in accepting it, it would need to be decided which arrows get drawn on top. I think it makes sense to put the pgn arrows on top since they're from the user, but you may have other thoughts.

